### PR TITLE
Fix HTTPS Record Creation - Add Support for ECH (Encrypted Client Hello)

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -120,6 +120,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 			Weight:  njallaRec.Weight,
 			Port:    njallaRec.Port,
 			Target:  njallaRec.Target,
+			Value:   njallaRec.Value,
 		}
 		var resp addRecordResponse
 
@@ -230,6 +231,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 			Weight:  njallaRec.Weight,
 			Port:    njallaRec.Port,
 			Target:  njallaRec.Target,
+			Value:   njallaRec.Value,
 		}
 		var resp njallaRecord
 
@@ -292,6 +294,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 				Weight:  njallaRec.Weight,
 				Port:    njallaRec.Port,
 				Target:  njallaRec.Target,
+				Value:   njallaRec.Value,
 			}
 			var resp njallaRecord
 
@@ -318,6 +321,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 				Weight:  njallaRec.Weight,
 				Port:    njallaRec.Port,
 				Target:  njallaRec.Target,
+				Value:   njallaRec.Value,
 			}
 			var resp addRecordResponse
 
@@ -481,6 +485,10 @@ func extractRecordID(record libdns.Record) string {
 			return pd["id"]
 		}
 	case libdns.SRV:
+		if pd, ok := r.ProviderData.(map[string]string); ok {
+			return pd["id"]
+		}
+	case libdns.ServiceBinding:
 		if pd, ok := r.ProviderData.(map[string]string); ok {
 			return pd["id"]
 		}

--- a/provider_test.go
+++ b/provider_test.go
@@ -1044,6 +1044,29 @@ func TestExtractRecordID(t *testing.T) {
 			expected: "srv-id",
 		},
 		{
+			name: "ServiceBinding with ID",
+			record: libdns.ServiceBinding{
+				Name:     "test",
+				Priority: 1,
+				Target:   "target.example.com",
+				Params:   make(libdns.SvcParams),
+				ProviderData: map[string]string{
+					"id": "service-id",
+				},
+			},
+			expected: "service-id",
+		},
+		{
+			name: "ServiceBinding without ID",
+			record: libdns.ServiceBinding{
+				Name:     "test",
+				Priority: 1,
+				Target:   "target.example.com",
+				Params:   make(libdns.SvcParams),
+			},
+			expected: "",
+		},
+		{
 			name: "Address without ID",
 			record: libdns.Address{
 				Name: "test",

--- a/types.go
+++ b/types.go
@@ -153,7 +153,35 @@ func njallaRecordToLibdns(record njallaRecord) (libdns.Record, error) {
 			},
 		}, nil
 
-	case "HTTPS", "SVCB":
+	case "HTTPS":
+		// Parse SvcParams from content if present
+		var params libdns.SvcParams
+		if record.Content != "" {
+			var err error
+			params, err = libdns.ParseSvcParams(record.Content)
+			if err != nil {
+				// If parsing fails, create empty params and store the content as a fallback
+				params = make(libdns.SvcParams)
+				// Store unparseable content as a fallback
+				params["_content"] = []string{record.Content}
+			}
+		} else {
+			// Initialize empty params if no content
+			params = make(libdns.SvcParams)
+		}
+
+		return libdns.ServiceBinding{
+			Name:     record.Name,
+			TTL:      recordTTL,
+			Priority: uint16(record.Prio),
+			Target:   record.Target,
+			Params:   params,
+			ProviderData: map[string]string{
+				"id": record.ID,
+			},
+		}, nil
+
+	case "SVCB":
 		// Parse SvcParams from content if present
 		var params libdns.SvcParams
 		if record.Content != "" {

--- a/types.go
+++ b/types.go
@@ -285,7 +285,7 @@ func libdnsRecordToNjalla(record libdns.Record, zone string) (njallaRecord, erro
 
 		// Handle SvcParams - serialize them to content field
 		// Note: This is a workaround since Njalla's API doesn't fully support SvcParams
-		if r.Params != nil && len(r.Params) > 0 {
+		if len(r.Params) > 0 {
 			// If there's a special _content key (from parsing errors), use it directly
 			if content, exists := r.Params["_content"]; exists && len(content) > 0 {
 				result.Content = content[0]


### PR DESCRIPTION
## 🔧 Fix HTTPS Record Creation - Add Support for ECH (Encrypted Client Hello)

### 🐛 **Problem**
The libdns-njalla plugin was failing to create HTTPS records needed for Caddy's ECH (Encrypted Client Hello) feature, with the following error:

```
API error: 400 - Missing required field for HTTPS record: value
```

**Root Cause**: Njalla's API requires a `"value"` field specifically for HTTPS records (undocumented), but the plugin was only sending SvcParams in the `"content"` field.

### ✅ **Solution**
Added proper support for HTTPS records by implementing the missing `"value"` field throughout the plugin architecture.

### 🔄 **Changes Made**

#### **API Structures Updated**
- Added `Value string` field to:
  - `addRecordRequest`
  - `editRecordRequest` 
  - `addRecordResponse`
  - `njallaRecord`

#### **HTTPS Record Logic Fixed**
- **For HTTPS records**: SvcParams now serialize to `"value"` field (not `"content"`)
- **Content field**: Stays empty for HTTPS records per Njalla API requirements
- **Backward compatibility**: All other record types unchanged

#### **Provider Methods Enhanced**
- Updated `AppendRecords()` and `SetRecords()` to populate `"value"` field
- Added `ServiceBinding` support to `extractRecordID()` function

#### **Comprehensive Testing**
- ✅ Added ServiceBinding test cases to `TestExtractRecordID`
- ✅ Updated HTTPS record tests to verify `"value"` field usage
- ✅ All existing tests pass (100% backward compatible)
- ✅ Real API testing confirmed fix works

### 🧪 **Testing Performed**

1. **API Testing**: Direct curl testing confirmed:
   - ❌ Without `"value"` field → `400 - Missing required field`
   - ✅ With `"value"` field → HTTPS record created successfully

2. **Integration Testing**: Live test with actual API:
   ```bash
   ✅ Successfully created HTTPS record with ECH support
   ✅ Record retrieved and verified in zone
   ✅ Record deletion successful
   ```

3. **Unit Testing**: All tests pass
   ```bash
   go test ./...  # ✅ PASS
   ```

### 📁 **Files Modified**
- `types.go` - Added `Value` field to API structures & updated HTTPS conversion logic
- `provider.go` - Updated API requests to include `Value` field & added ServiceBinding ID extraction
- `types_test.go` - Enhanced HTTPS record tests for `"value"` field handling
- `provider_test.go` - Added ServiceBinding test cases for complete coverage

### 🎯 **Impact**
- **🔓 Enables ECH Support**: Caddy can now create HTTPS records for ECH functionality
- **🛡️ Backward Compatible**: No breaking changes to existing record types
- **🔧 Future-Proof**: Proper foundation for advanced HTTPS record features

### 🚀 **Before/After**

**Before:**
```
{"level":"error","msg":"unable to publish ECH data to HTTPS DNS record",
 "error":"failed to add record: API error: 400 - Missing required field for HTTPS record: value"}
```

**After:**
```
{"level":"info","ts":1751479570.2883856,"logger":"tls","msg":"published ECH configuration list","domains":["test01.domain.com","test02.domain.com"],"config_ids":[117]}
{"level":"info","ts":1751479578.9448779,"logger":"tls.obtain","msg":"certificate obtained successfully","identifier":"ech.domain.com","issuer":"acme-v02.api.letsencrypt.org-directory"}
{"level":"info","ts":1751479578.1048992,"logger":"tls.obtain","msg":"certificate obtained successfully","identifier":"test01.domain.com","issuer":"acme-v02.api.letsencrypt.org-directory"}
{"level":"info","ts":1751479579.6942563,"logger":"tls.obtain","msg":"certificate obtained successfully","identifier":"test02.domain.com","issuer":"acme-v02.api.letsencrypt.org-directory"}
```

### Logs:
https://logs.notifiarr.com/?20cbe19eba459b38#CLLZ9MoHXMrSmQYKFXi8N3yViTitcGowKH28eAiEdha1

### Screenshot from njalla (after Caddy creates HTTPS records for ECH)
https://up.shx.gg/7bzufO1fM.png
